### PR TITLE
Add scalaz Future and Task benchmarks

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,6 +4,9 @@ version := "1.0"
 
 scalaVersion := "2.11.7"
 
-libraryDependencies += "org.scala-lang.modules" %% "scala-async" % "0.9.5"
+libraryDependencies ++= Seq(
+  "org.scala-lang.modules" %% "scala-async" % "0.9.5",
+  "org.scalaz" %% "scalaz-concurrent" % "7.1.5"
+)
 
 enablePlugins(JmhPlugin)

--- a/src/main/scala/com/gvolpe/computations/ScalazFutureCase.scala
+++ b/src/main/scala/com/gvolpe/computations/ScalazFutureCase.scala
@@ -1,0 +1,16 @@
+package com.gvolpe.computations
+
+import scala.concurrent.duration._
+import scalaz.Scalaz._
+import scalaz.concurrent.Future
+
+object ScalazFutureCase extends SumResult {
+  override def sumResult: Double = {
+    val futures = Vector(Future(Math.sqrt(7891.12)), Future(Math.sqrt(995522.54)), Future(Math.sqrt(359.87)))
+    val sum = for {
+      v <- futures.sequence[Future, Double]
+    } yield v.sum
+
+    sum.runFor(200 millis)
+  }
+}

--- a/src/main/scala/com/gvolpe/computations/ScalazFutureCase.scala
+++ b/src/main/scala/com/gvolpe/computations/ScalazFutureCase.scala
@@ -5,8 +5,10 @@ import scalaz.Scalaz._
 import scalaz.concurrent.Future
 
 object ScalazFutureCase extends SumResult {
+
+  val futures = Vector(Future(Math.sqrt(7891.12)), Future(Math.sqrt(995522.54)), Future(Math.sqrt(359.87)))
+
   override def sumResult: Double = {
-    val futures = Vector(Future(Math.sqrt(7891.12)), Future(Math.sqrt(995522.54)), Future(Math.sqrt(359.87)))
     val sum = for {
       v <- futures.sequence[Future, Double]
     } yield v.sum

--- a/src/main/scala/com/gvolpe/computations/ScalazTaskCase.scala
+++ b/src/main/scala/com/gvolpe/computations/ScalazTaskCase.scala
@@ -5,8 +5,10 @@ import scalaz.Scalaz._
 import scalaz.concurrent.Task
 
 object ScalazTaskCase extends SumResult {
+
+  val futures = Vector(Task(Math.sqrt(7891.12)), Task(Math.sqrt(995522.54)), Task(Math.sqrt(359.87)))
+
   override def sumResult: Double = {
-    val futures = Vector(Task(Math.sqrt(7891.12)), Task(Math.sqrt(995522.54)), Task(Math.sqrt(359.87)))
     val sum = for {
       v <- futures.sequence[Task, Double]
     } yield v.sum

--- a/src/main/scala/com/gvolpe/computations/ScalazTaskCase.scala
+++ b/src/main/scala/com/gvolpe/computations/ScalazTaskCase.scala
@@ -1,0 +1,17 @@
+package com.gvolpe.computations
+
+import scala.concurrent.duration._
+import scalaz.Scalaz._
+import scalaz.concurrent.Task
+
+object ScalazTaskCase extends SumResult {
+  override def sumResult: Double = {
+    val futures = Vector(Task(Math.sqrt(7891.12)), Task(Math.sqrt(995522.54)), Task(Math.sqrt(359.87)))
+    val sum = for {
+      v <- futures.sequence[Task, Double]
+    } yield v.sum
+
+    sum.runFor(200 millis)
+  }
+}
+

--- a/src/main/scala/com/gvolpe/computations/benchmarks/FutureBenchmark.scala
+++ b/src/main/scala/com/gvolpe/computations/benchmarks/FutureBenchmark.scala
@@ -2,7 +2,7 @@ package com.gvolpe.computations.benchmarks
 
 import java.util.concurrent.TimeUnit
 
-import com.gvolpe.computations.{FutureSequenceCase, FutureCase, AsyncAwaitCase}
+import com.gvolpe.computations._
 import org.openjdk.jmh.annotations.{Benchmark, Mode, OutputTimeUnit, BenchmarkMode}
 
 @BenchmarkMode(Array(Mode.AverageTime))
@@ -17,5 +17,11 @@ class FutureBenchmark {
 
   @Benchmark
   def asyncAwaitResult: Unit = AsyncAwaitCase.sumResult
+
+  @Benchmark
+  def scalazFutureResult: Unit = ScalazFutureCase.sumResult
+
+  @Benchmark
+  def scalazTaskResult: Unit = ScalazTaskCase.sumResult
 
 }


### PR DESCRIPTION
The results on my computer:

```
[info] Benchmark                             Mode  Cnt      Score      Error  Units
[info] FutureBenchmark.asyncAwaitResult      avgt    9   3056.521 ± 2958.249  ns/op
[info] FutureBenchmark.futureResult          avgt    9   6025.056 ±   88.174  ns/op
[info] FutureBenchmark.futureSequenceResult  avgt    9   8751.979 ±  184.327  ns/op
[info] FutureBenchmark.scalazFutureResult    avgt    9  14796.189 ±  786.968  ns/op
[info] FutureBenchmark.scalazTaskResult      avgt    9  15815.409 ±  873.325  ns/op
```
